### PR TITLE
2.2.0 Updating channel size limits from 1-99

### DIFF
--- a/autochannel/api/routes.py
+++ b/autochannel/api/routes.py
@@ -148,8 +148,8 @@ def update_channel_size_cat():
     msg=''
     channel_id = request.form.get('channel_id')
     channel_size = int(request.form.get('channel_size'))
-    if channel_size < 2 or channel_size > 20:
-        return jsonify(error='channel size can not be 1 or greater than 20'), 400
+    if channel_size < 1 or channel_size > 99:
+        return jsonify(error='channel size can not less 0 or greater than 99'), 400
     data_functions.data_update_cat_channel_size(channel_id=channel_id, channel_size=channel_size)
     msg = f'Updated channel size for category: {channel_id} to: {channel_size} '
     return jsonify(data=msg)

--- a/autochannel/templates/pages/guild-categories.html
+++ b/autochannel/templates/pages/guild-categories.html
@@ -39,7 +39,7 @@ Categories for {{guild[g_info]['name']}}: {{session['user']['username'] }}
                                     created channel, must be unique for channels in this
                                     category (default AC!: Example [NA] Squad)" scope="col">Prefix</th>
                                     <th data-toggle="tooltip" title="Number of users that
-                                    can be in each channel must be between 2-20 (default 10)" scope="col">Channel Size</th>
+                                    can be in each channel must be between 1-99 (default 10)" scope="col">Channel Size</th>
                                     <th data-toggle="tooltip" title="Number of empty
                                     channels AutoChannel keeps in category (default 1)" scope="col">Empty Count</th>
                                 </tr>
@@ -71,7 +71,7 @@ Categories for {{guild[g_info]['name']}}: {{session['user']['username'] }}
                                             value="{{db_categories[cat]['channel_size']}}"
                                             class="form-control" aria-label="Small"
                                             aria-describedby="inputGroup-sizing-sm"
-                                            min="2" max="20" >
+                                            min="1" max="99" >
                                             <div class="input-group-append">
                                                     <button
                                                     cname="{{discord_categories[cat|string]['name']}}"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ TEST_REQUIREMENTS = {
 
 setup(
     name='AutoChannel-ui',
-    version='2.1.0',
+    version='2.2.0',
     description='AutoChannel Discord Bot API',
     url='https://github.com/hhollenstain/autochannel-ui',
     packages=find_packages(),


### PR DESCRIPTION
# Changes
- Channel size now updated from 2-20, to 1-99 due to use cases mentioned in auto-chan support discord